### PR TITLE
Fixed __repr__ functions to return strings

### DIFF
--- a/apps/ad-qolsys/door_window.py
+++ b/apps/ad-qolsys/door_window.py
@@ -86,17 +86,17 @@ class door_window:
         return me
     
     def __repr__(self):
-        me = {
-            "zoneid": self.zoneid,
-            "entity_id": self.entity_id,
-            "friendly_name": self.friendly_name,
-            "state": self.state,
-            "partition_id": self.partition_id,
-            "device_class": self.device_class,
-            "payload_on": self.payload_on,
-            "payload_off": self.payload_off,
-            "config_topic": self.config_topic,
-            "state_topic": self.state_topic,
-            "availability": self.availability_list
-        }
+        me = f'{{' \
+            f'"zoneid": self.zoneid,' \
+            f'"entity_id": self.entity_id,' \
+            f'"friendly_name": self.friendly_name,' \
+            f'"state": self.state,' \
+            f'"partition_id": self.partition_id,' \
+            f'"device_class": self.device_class,' \
+            f'"payload_on": self.payload_on,' \
+            f'"payload_off": self.payload_off,' \
+            f'"config_topic": self.config_topic,' \
+            f'"state_topic": self.state_topic,' \
+            f'"availability": self.availability_list' \
+        f'}}'
         return me

--- a/apps/ad-qolsys/partition.py
+++ b/apps/ad-qolsys/partition.py
@@ -143,14 +143,14 @@ class partition:
         return me
     
     def __repr__(self):
-        me = {
-            "id": self.p_id,
-            "name": self.name,
-            "status": self.status,
-            "entity_id": self.entity_id,
-            "alarm_panel_config_topic": self.alarm_panel_config_topic,
-            "alarm_panel_state_topic": self.alarm_panel_state_topic,
-            "code": self.code,
-            "zones": self.zones
-        }
+        me = f'{{' \
+            f'"id": self.p_id,' \
+            f'"name": self.name,' \
+            f'"status": self.status,' \
+            f'"entity_id": self.entity_id,' \
+            f'"alarm_panel_config_topic": self.alarm_panel_config_topic,' \
+            f'"alarm_panel_state_topic": self.alarm_panel_state_topic,' \
+            f'"code": self.code,' \
+            f'"zones": self.zones' \
+        f'}}'
         return me


### PR DESCRIPTION
Fixed __repr__ functions so they actually return a string representation of the dict, as expected (not a dict object). Prevents logging errors due to not getting a printable string.