### PR TITLE
Secure arming & codes with leading zeros

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ qolsys_alarming_event_topic: (Optional) The topic to publish ARMING events to; d
 qolsys_disarming_event_topic: (Optional) The topic to publish DISARMING events to; defaults to qolsys/disarming
 qolsys_confirm_disarm_code: True/False (Optional) Require the code for disarming; defaults to False
 qolsys_confirm_arm_code: True/False (Optional) Require the code for arming; defaults to False
-qolsys_disarm_code: (Required to disarm the alarm; also required to arm "Secure Arm" is enabled in Dealer Settings > Security & Arming, otherwise IQ panel may crash; wrap codes with leading zeros in quotes!)
+qolsys_disarm_code: (Required to disarm the alarm; also required to arm if "Secure Arm" is enabled in Dealer Settings > Security & Arming, otherwise IQ panel may crash; wrap codes with leading zeros in quotes!)
 qolsys_arm_away_always_instant: True/False (Optional) Set to true if all Arm Away commands should be instant; defaults to False
 homeassistant_mqtt_discovery_topic: homeassistant/ (Optional) The topic Home Assistant is using for MQTT Discovery (homeassistant/ is the default in HA and here)
 mqtt_state_topic: mqtt-states (Optional) The topic to publish state updates to for the alarm_control_panel and binary_sensor (default: mqtt-states)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ qolsys_alarming_event_topic: (Optional) The topic to publish ARMING events to; d
 qolsys_disarming_event_topic: (Optional) The topic to publish DISARMING events to; defaults to qolsys/disarming
 qolsys_confirm_disarm_code: True/False (Optional) Require the code for disarming; defaults to False
 qolsys_confirm_arm_code: True/False (Optional) Require the code for arming; defaults to False
-qolsys_disarm_code: (Required to disarm the alarm; also required to arm "Secure Arm" is enabled in Dealer Settings > Security & Arming, otherwise IQ panel may crash)
+qolsys_disarm_code: (Required to disarm the alarm; also required to arm "Secure Arm" is enabled in Dealer Settings > Security & Arming, otherwise IQ panel may crash; wrap codes with leading zeros in quotes!)
 qolsys_arm_away_always_instant: True/False (Optional) Set to true if all Arm Away commands should be instant; defaults to False
 homeassistant_mqtt_discovery_topic: homeassistant/ (Optional) The topic Home Assistant is using for MQTT Discovery (homeassistant/ is the default in HA and here)
 mqtt_state_topic: mqtt-states (Optional) The topic to publish state updates to for the alarm_control_panel and binary_sensor (default: mqtt-states)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ qolsys_alarming_event_topic: (Optional) The topic to publish ARMING events to; d
 qolsys_disarming_event_topic: (Optional) The topic to publish DISARMING events to; defaults to qolsys/disarming
 qolsys_confirm_disarm_code: True/False (Optional) Require the code for disarming; defaults to False
 qolsys_confirm_arm_code: True/False (Optional) Require the code for arming; defaults to False
-qolsys_disarm_code: (Required - if you want to disarm the alarm)
+qolsys_disarm_code: (Required to disarm the alarm; also required to arm "Secure Arm" is enabled in Dealer Settings > Security & Arming, otherwise IQ panel may crash)
 qolsys_arm_away_always_instant: True/False (Optional) Set to true if all Arm Away commands should be instant; defaults to False
 homeassistant_mqtt_discovery_topic: homeassistant/ (Optional) The topic Home Assistant is using for MQTT Discovery (homeassistant/ is the default in HA and here)
 mqtt_state_topic: mqtt-states (Optional) The topic to publish state updates to for the alarm_control_panel and binary_sensor (default: mqtt-states)

--- a/apps/ad-qolsys/partition.py
+++ b/apps/ad-qolsys/partition.py
@@ -1,7 +1,7 @@
 import re
 
 class partition:
-    def __init__(self, p_id: int, name: str, status: str, code: int, confirm_code_arm: bool, confirm_code_disarm: bool, token: str, **kwargs):
+    def __init__(self, p_id: int, name: str, status: str, code: str, confirm_code_arm: bool, confirm_code_disarm: bool, token: str, **kwargs):
         """ Arguments:
         id: int
         name: str
@@ -89,11 +89,12 @@ class partition:
         return self.__code
 
     @code.setter
-    def code(self, code: int):
-        self.__code = int()
+    def code(self, code: str):
+        self.__code = str()
         try:
             if int(code) and len(str(code))>=4:
-                self.__code = int(code)
+                # use a string to store the code to accomodate leading zeros
+                self.__code = str(code)
             else:
                 raise ValueError("Not a valid code")
         except:

--- a/apps/ad-qolsys/partition.py
+++ b/apps/ad-qolsys/partition.py
@@ -48,7 +48,7 @@ class partition:
         self.alarm_panel_config_topic = self.homeassistant_mqtt_discovery_topic + "alarm_control_panel/qolsys/" + self.entity_id + "/config"
         self.alarm_panel_state_topic = self.mqtt_state_topic + "alarm_control_panel/qolsys/" + self.entity_id + "/state"
         self.availability_topic = self.mqtt_availability_topic + "alarm_control_panel/qolsys/" + self.entity_id + "/availability"
-        self.command_template = '{"event":"{% if action == \"ARM_HOME\" or action == \"ARM_AWAY\" or action == \"ARM_NIGHT\" %}ARM","arm_type":"{% if action == \"ARM_HOME\" or action == \"ARM_NIGHT\" %}stay{% else %}away{% endif %}"{% else %}{{action}}", "usercode":"' + str(self.code) + '"{% endif %}, "token":"' + self.token + '", "partition_id":"' + str(self.p_id) + '"}'
+        self.command_template = '{"event":"{% if action == \"ARM_HOME\" or action == \"ARM_AWAY\" or action == \"ARM_NIGHT\" %}ARM","arm_type":"{% if action == \"ARM_HOME\" or action == \"ARM_NIGHT\" %}stay{% else %}away{% endif %}"{% else %}{{action}}"{% endif %}, "usercode":"' + str(self.code) + '", "token":"' + self.token + '", "partition_id":"' + str(self.p_id) + '"}'
         
     @property
     def availability_list(self):

--- a/apps/ad-qolsys/qolsys_requests.py
+++ b/apps/ad-qolsys/qolsys_requests.py
@@ -272,12 +272,9 @@ class MQTTSubscriber:
                             "source":       "C4",
                             "version_key":  1,
                             "source_key":   "C4",
-                            "token":        token
+                            "token":        token,
+                            "usercode":     usercode
                         }
-
-        #Disarm requires a usercode
-        if arming_type.lower() == "disarm":
-            armString.update({"usercode":usercode})
 
         if arming_type.lower() == "away" and instant:
             armString.update({"delay": 0})


### PR DESCRIPTION
My Qolsys panel has secure arming enabled which requires the input of the user code to arm the panel. This can be enabled through Dealer Settings > Security & Arming. With this change it might make sense to change the YAML variable "qolsys_disarm_code" to "qolsys_usercode" but I leave that up to the community.

I also tested my alarm after disabling Secure Arming and it doesn't seem to mind receiving the usercode if it's isn't required so this shouldn't effect people who don't have it enabled.

I've also made adjusted code to be stored as string instead of integer so codes that start with leading zeros don't get shortened. For example:

`str(int(0050)) == '50'`